### PR TITLE
PgMana: changes and fixes

### DIFF
--- a/postgres_v8.4.x/pg_mana/CHANGELOG.md
+++ b/postgres_v8.4.x/pg_mana/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.2.0] - 2025-10-25
+### Changed
+- The `kill_idle` function considers only backends with state *<IDLE> in transaction*.
+
+### Fixed
+- The `schema_size` view was fixed to show the correct size of schemas.

--- a/postgres_v8.4.x/pg_mana/README.md
+++ b/postgres_v8.4.x/pg_mana/README.md
@@ -1,4 +1,4 @@
-# Management Module - pgmana v0.1.0
+# Management Module - pgmana v0.2.0
 
 This module's aim is to streamline administrative tasks commonly performed by DBAs in **PostgreSQL v8.4.x**.
 It requires **plpgsql** to work correctly.
@@ -12,7 +12,7 @@ Make sure the **plpgsql** is activated in the target database, and then execute 
 
 `kill_idle(duration interval)` &rarr; `void`
 
-Terminates backends with idle sessions greater than or equal to **duration**. Only superusers can execute it.
+Terminates *idle in transaction* backends whose session time is greater than or equal to **duration**. Only superusers can execute it.
 
 **Parameters:**
 - duration - threshold for idle session time (default 15 minutes)
@@ -45,7 +45,7 @@ See the meaning of attributes at pg_cast documentation https://www.postgresql.or
 
 `schema_size`
 
-Lists the total size of schemas. It considers all objects in the schema.
+Lists the total size of schemas. It considers all objects in the schema, except **large objects**.
 
 **Attributes:**
 - name - schema's name

--- a/postgres_v8.4.x/pg_mana/pgmana.sql
+++ b/postgres_v8.4.x/pg_mana/pgmana.sql
@@ -19,15 +19,16 @@ returns void
 language plpgsql as
 $$
 begin
-	perform pg_terminate_backend(procpid) from pg_stat_activity
+	perform pg_terminate_backend(procpid)
+	from pg_stat_activity
 	where waiting=false
-	and current_query in ('<IDLE>','<IDLE> in transaction')
+	and current_query='<IDLE> in transaction'
 	and (current_timestamp-query_start) >= duration;
 end;
 $$;
 
 comment on function kill_idle(interval) is
-'Terminates backends with idle sessions greater than or equal to "duration".
+'Terminates "idle in transaction" backends whose session time is greater than or equal to "duration".
 Parameters:
 	duration - threshold for idle session time (default 15 minutes)
 ';
@@ -82,10 +83,11 @@ comment on column all_casts."method" is 'It is pg_cast.castmethod attribute';
 
 -- Schema size
 
-create view schema_size(name,size) as
-select s.nspname,sum(pg_relation_size(c.oid))
+create or replace view schema_size(name,size) as
+select s.nspname,sum(pg_total_relation_size(c.oid))
 from pg_class c
 join pg_namespace s on (c.relnamespace=s.oid)
+where c.relkind='r'
 group by s.nspname;
 
 comment on view schema_size is 'Lists the total size of schemas. It considers all objects in the schema.';


### PR DESCRIPTION
The kill_idle function was changed to consider only backends with state "<IDLE> in transaction".

The schema_size view was fixed to show the correct size of schemas.

A changelog file was added for pgmana.